### PR TITLE
Add support for API prefix via env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,15 @@ COPY package*.json ./
 RUN npm install
 
 COPY . .
+
 RUN cp -n env.example .env
 
-RUN npm run build
+RUN chmod +x snapshotter_autofill.sh
 
 EXPOSE 3000
 
 ENV HOST=0.0.0.0
 
 CMD [ "npm", "run", "preview", "--", "--host"]
+
+ENTRYPOINT ["sh", "-c", "sh snapshotter_autofill.sh && npm run build && npm run preview -- --host"]

--- a/snapshotter_autofill.sh
+++ b/snapshotter_autofill.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#This script is run from high level docker-compose. Refer to https://github.com/PowerLoom/deploy
+set -e
+
+echo 'populating settings from environment values...';
+
+cp  env.example .env
+
+if [ "$POOLER_API_PREFIX" ]; then
+    echo "Found POOLER_API_PREFIX ${POOLER_API_PREFIX}";
+    sed -i'.backup' "s#http://localhost:8002#$POOLER_API_PREFIX#" .env
+fi
+
+cat .env
+
+echo 'settings has been populated!'


### PR DESCRIPTION
Support for Powerloom/deploy#14

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.

### Current behaviour
.env gets prefilled with a default `API_PREFIX` supplied in the example file for docker setups.

### New expected behaviour
If `POOLER_API_PREFIX` is passed via environment, that dynamically changes the default value. For manual setups, an existing `.env` still takes precedence.